### PR TITLE
Ensure strict JSON schema compliance for OpenAI predictions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -559,9 +559,12 @@ def call_openai_predictions_strict(matchday_index: int,
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": True,
+                "additionalProperties": False,
                 "properties": {
+                    "title": {"type": "string"},
                     "url": {"type": "string"},
+                    "accessed": {"type": "string"},
+                    "note": {"type": "string"},
                 },
                 "required": ["url"],
             },

--- a/bot.py
+++ b/bot.py
@@ -517,9 +517,20 @@ def call_openai_predictions_strict(matchday_index: int,
                 "home_win": {"type": "number", "minimum": 0, "maximum": 1},
                 "draw": {"type": "number", "minimum": 0, "maximum": 1},
                 "away_win": {"type": "number", "minimum": 0, "maximum": 1},
-                "over_2_5": {"type": "number", "minimum": 0, "maximum": 1},
-                "btts_yes": {"type": "number", "minimum": 0, "maximum": 1},
+                "over_2_5": {
+                    "anyOf": [
+                        {"type": "number", "minimum": 0, "maximum": 1},
+                        {"type": "null"},
+                    ]
+                },
+                "btts_yes": {
+                    "anyOf": [
+                        {"type": "number", "minimum": 0, "maximum": 1},
+                        {"type": "null"},
+                    ]
+                },
             },
+            "required": ["home_win", "draw", "away_win", "over_2_5", "btts_yes"],
         },
         "top_scorelines": {
             "type": "array",
@@ -542,6 +553,7 @@ def call_openai_predictions_strict(matchday_index: int,
                 "draw": {"type": ["number", "null"]},
                 "away": {"type": ["number", "null"]},
             },
+            "required": ["home", "draw", "away"],
         },
         "sources": {
             "type": "array",
@@ -549,9 +561,7 @@ def call_openai_predictions_strict(matchday_index: int,
                 "type": "object",
                 "additionalProperties": True,
                 "properties": {
-                    "title": {"type": "string"},
                     "url": {"type": "string"},
-                    "accessed": {"type": "string"},
                 },
                 "required": ["url"],
             },


### PR DESCRIPTION
## Summary
- update the prediction schema so the strict JSON schema validator includes required entries for probability and odds objects
- relax optional source metadata while keeping URL validation so responses continue to pass strict checks

## Testing
- python3 -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d94623aca0832e8641d9223357e430