### PR TITLE
Relax source metadata schema

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -500,7 +500,7 @@ def call_openai_predictions_strict(matchday_index: int,
 
     n = len(rows)
 
-    # --- JSON-Schema: Pflichtfelder + optionale Research-Felder
+    # --- JSON-Schema: Pflichtfelder + optionale Research-Felder (dürfen Null/leer sein)
     item_props = {
         "row_index": {"type": "integer", "minimum": 1, "maximum": n},
         "matchday": {"type": "integer"},
@@ -511,7 +511,7 @@ def call_openai_predictions_strict(matchday_index: int,
         "reason": {"type": "string", "maxLength": 250},
         # optional (research)
         "probabilities": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": False,
             "properties": {
                 "home_win": {"type": "number", "minimum": 0, "maximum": 1},
@@ -533,7 +533,7 @@ def call_openai_predictions_strict(matchday_index: int,
             "required": ["home_win", "draw", "away_win", "over_2_5", "btts_yes"],
         },
         "top_scorelines": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
                 "type": "object",
                 "additionalProperties": False,
@@ -546,7 +546,7 @@ def call_openai_predictions_strict(matchday_index: int,
             "minItems": 0, "maxItems": 3,
         },
         "odds_used": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": False,
             "properties": {
                 "home": {"type": ["number", "null"]},
@@ -556,7 +556,7 @@ def call_openai_predictions_strict(matchday_index: int,
             "required": ["home", "draw", "away"],
         },
         "sources": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
                 "type": "object",
                 "additionalProperties": False,
@@ -572,6 +572,8 @@ def call_openai_predictions_strict(matchday_index: int,
         },
     }
 
+    required_keys = list(item_props.keys())
+
     schema = {
         "type": "object",
         "additionalProperties": False,
@@ -584,10 +586,7 @@ def call_openai_predictions_strict(matchday_index: int,
                     "type": "object",
                     "additionalProperties": False,
                     "properties": item_props,
-                    "required": [
-                        "row_index", "matchday", "home_team", "away_team",
-                        "predicted_home_goals", "predicted_away_goals", "reason"
-                    ],
+                    "required": required_keys,
                 },
             }
         },

--- a/bot.py
+++ b/bot.py
@@ -609,7 +609,7 @@ def call_openai_predictions_strict(matchday_index: int,
     def _build_prompt():
         if prompt_profile == "research":
             return build_prompt_research(matchday_index, rows)
-        return build_prompt_minimal(matchday_index, rows)
+        return build_prompt(matchday_index, rows)
 
     last_err = None
     for attempt in range(1, max_retries + 1):
@@ -787,6 +787,7 @@ def main():
     ap.add_argument("--oa-timeout", type=float, default=None)
 
     ap.add_argument("--max-retries", type=int, default=None)
+    ap.add_argument("--prompt-profile", default=None)
     ap.add_argument("--allow-heuristic-fallback", action="store_true",
                     help="Nur für Notfälle. Wenn gesetzt, wird NIE 1:1 genommen; aber heuristisch aus Quoten geschätzt.")
     ap.add_argument("--no-submit", action="store_true")
@@ -810,7 +811,7 @@ def main():
     oa_timeout = resolve_value(args.oa_timeout, ["OPENAI_TIMEOUT", "OA_TIMEOUT"], ["oa_timeout", "timeout", "openai_timeout"], ini_sections, cfg, float, 45.0)
     max_retries = resolve_value(args.max_retries, ["OPENAI_MAX_RETRIES"], ["max_retries", "retries"], ini_sections, cfg, int, 3)
     allow_heuristic = args.allow_heuristic_fallback or parse_bool(get_ini_value(cfg, ["allow_heuristic_fallback"], ini_sections), False)
-    prompt_profile = resolve_value(args.model, ["OPENAI_PROMPT_PROFILE"], ["promptprofile", "prompt_profile"], ini_sections, cfg, str, "research")
+    prompt_profile = resolve_value(args.prompt_profile, ["OPENAI_PROMPT_PROFILE"], ["promptprofile", "prompt_profile"], ini_sections, cfg, str, "research")
 
     no_submit = args.no_submit or parse_bool(get_ini_value(cfg, ["no_submit"], ini_sections), False)
     proxy = resolve_value(args.proxy, ["HTTPS_PROXY", "HTTP_PROXY"], ["proxy", "https_proxy", "http_proxy"], ini_sections, cfg, str, None)

--- a/bot.py
+++ b/bot.py
@@ -517,9 +517,20 @@ def call_openai_predictions_strict(matchday_index: int,
                 "home_win": {"type": "number", "minimum": 0, "maximum": 1},
                 "draw": {"type": "number", "minimum": 0, "maximum": 1},
                 "away_win": {"type": "number", "minimum": 0, "maximum": 1},
-                "over_2_5": {"type": "number", "minimum": 0, "maximum": 1},
-                "btts_yes": {"type": "number", "minimum": 0, "maximum": 1},
+                "over_2_5": {
+                    "anyOf": [
+                        {"type": "number", "minimum": 0, "maximum": 1},
+                        {"type": "null"},
+                    ]
+                },
+                "btts_yes": {
+                    "anyOf": [
+                        {"type": "number", "minimum": 0, "maximum": 1},
+                        {"type": "null"},
+                    ]
+                },
             },
+            "required": ["home_win", "draw", "away_win", "over_2_5", "btts_yes"],
         },
         "top_scorelines": {
             "type": "array",
@@ -542,16 +553,18 @@ def call_openai_predictions_strict(matchday_index: int,
                 "draw": {"type": ["number", "null"]},
                 "away": {"type": ["number", "null"]},
             },
+            "required": ["home", "draw", "away"],
         },
         "sources": {
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": True,
+                "additionalProperties": False,
                 "properties": {
-                    "title": {"type": "string"},
                     "url": {"type": "string"},
-                    "accessed": {"type": "string"},
+                },
+                "patternProperties": {
+                    "^(title|accessed|note)$": {"type": "string"},
                 },
                 "required": ["url"],
             },


### PR DESCRIPTION
## Summary
- allow optional source metadata keys without violating strict schema requirements

## Testing
- python3 -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d94623aca0832e8641d9223357e430